### PR TITLE
Dump tool call result to prompts store

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -40,6 +40,10 @@ class PromptRequest(BaseModel):
     prompt: str
 
 
+class ToolCallResultRequest(BaseModel):
+    result: str
+
+
 @app.post("/prompt")
 async def generate_prompt(request: PromptRequest):
     response = llm_client.generate(request.prompt)
@@ -47,6 +51,12 @@ async def generate_prompt(request: PromptRequest):
         prompt=request.prompt, response=response
     )
     return {"response": response, "promptId": prompt_id}
+
+
+@app.patch("/tool-call/{promptId}")
+async def update_tool_call(promptId: str, request: ToolCallResultRequest):
+    prompts_store.update_tool_call_result(prompt_id=promptId, tool_call_result=request.result)
+    return {"status": "ok"}
 
 
 if __name__ == "__main__":

--- a/backend/service/utils/prompts_store.py
+++ b/backend/service/utils/prompts_store.py
@@ -17,3 +17,8 @@ class PromptsStore:
             {"promptId": prompt_id, "prompt": prompt, "response": response}
         )
         return prompt_id
+
+    def update_tool_call_result(self, prompt_id: str, tool_call_result: str):
+        self.collection.update_one(
+            {"promptId": prompt_id}, {"$set": {"toolCallResult": tool_call_result}}
+        )

--- a/frontend/src/components/Chatbot.tsx
+++ b/frontend/src/components/Chatbot.tsx
@@ -33,6 +33,7 @@ const Chatbot: React.FC = () => {
         const response = await axios.post(`${apiHost}/prompt`, { prompt: promptString });
         console.log(promptString);
         console.log(response.data);
+        const promptId = response.data.promptId;
         getLocation();
         console.log(LOCATION_RESULT.result);
 
@@ -43,7 +44,8 @@ const Chatbot: React.FC = () => {
           console.log(`Tool call result: ${toolCallResult}`);
           if (toolCallResult !== null) {
             if (toolCallResult !== "") {
-              setMessages(prevMessages => [...prevMessages, { text: toolCallResult, sender: 'bot' }])
+              setMessages(prevMessages => [...prevMessages, { text: toolCallResult, sender: 'bot' }]);
+              await axios.patch(`${apiHost}/tool-call/${promptId}`, { result: toolCallResult });
             } else {
               setMessages(prevMessages => [...prevMessages, { text: `Ok, executing tool: ${parsedResponse['name']}`, sender: 'bot' }]);
             }


### PR DESCRIPTION
Closes #9 
Closes #5 

- Stores tool call results in prompts store by exposing a `PATCH /tool-call/{promptId}` call. 
- This will store results only if the tool call was successful and had a result to store (will not call this if there is no result, e.g. for the playSound tool). 