### PR TITLE
Add model mode switching

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -1,12 +1,14 @@
 from contextlib import asynccontextmanager
 import logging
 import asyncio
-from fastapi import FastAPI, WebSocket
+from fastapi import FastAPI, WebSocket, HTTPException
 from fastapi.websockets import WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from typing import Optional
 from fastapi.responses import StreamingResponse
+from enum import Enum
+import gc
 
 from service.model import (
     CommunicationAgent,
@@ -21,21 +23,31 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
+class Mode(Enum):
+    TEXT = "text"
+    VOICE = "voice"
+
+
 prompts_store: Optional[PromptsStore] = None
 memory_agent: Optional[MemoryAgent] = None
 memory_queue: Optional[asyncio.Queue] = None
 comm_agent: Optional[CommunicationAgent] = None
 voice_agent: Optional[VoiceCommunicationAgent] = None
 voice_memory_agent: Optional[VoiceMemoryAgent] = None
+current_mode: Mode = Mode.TEXT
 
 
 async def memory_processor():
-    global memory_queue, memory_agent
+    global memory_queue, memory_agent, voice_memory_agent
 
     while True:
         try:
             user_message = await memory_queue.get()
-            asyncio.create_task(memory_agent.store_memory(user_message))
+
+            if current_mode == Mode.TEXT:
+                asyncio.create_task(memory_agent.store_memory(user_message))
+            else:
+                asyncio.create_task(voice_memory_agent.store_memory(user_message))
             memory_queue.task_done()
         except asyncio.CancelledError:
             logging.error("Memory processor cancelled")
@@ -51,8 +63,6 @@ async def lifespan(app: FastAPI):
     prompts_store = PromptsStore()
     memory_agent = MemoryAgent()
     comm_agent = CommunicationAgent()
-    voice_agent = VoiceCommunicationAgent()
-    voice_memory_agent = VoiceMemoryAgent()
     memory_queue = asyncio.Queue(maxsize=1000)
 
     memory_task = asyncio.create_task(memory_processor())
@@ -120,6 +130,14 @@ async def update_tool_call(promptId: str, request: ToolCallResultRequest):
 
 @app.post("/aprompt")
 async def generate_aprompt(request: PromptRequest):
+    global current_mode
+
+    if current_mode != Mode.TEXT:
+        raise HTTPException(
+            status_code=500,
+            detail="Switch to text mode first using '/switch?mode='voice''",
+        )
+
     prompt_with_tools = f"{request.frontendTools}\n\n{request.prompt}"
 
     async def generate_chunks():
@@ -140,8 +158,54 @@ async def generate_aprompt(request: PromptRequest):
 
 @app.post("/vprompt")
 async def generate_vprompt():
-    # memory_queue.put_nowait("")
+    global current_mode
+
+    if current_mode != Mode.VOICE:
+        raise HTTPException(
+            status_code=500,
+            detail="Switch to voice mode first using '/switch?mode='voice''",
+        )
+
+    memory_queue.put_nowait("")
     return {"response": voice_agent.generate("")}
+
+
+@app.post("/switch")
+async def switch_mode(mode: Mode):
+    global current_mode
+    global comm_agent, voice_agent
+    global memory_agent, voice_memory_agent
+
+    if mode == current_mode:
+        logger.info(f"Nothing to switch, already in {mode.value}")
+        return {"status": "ok"}
+
+    logger.info(f"Switching from {current_mode.value} to {mode.value}")
+
+    if mode == Mode.TEXT and current_mode == Mode.VOICE:
+        logger.info("Off-loading voice agents, loading text agents")
+        voice_agent = None
+        voice_memory_agent = None
+        gc.collect()
+
+        comm_agent = CommunicationAgent()
+        memory_agent = MemoryAgent()
+        logger.info("Successfully loaded text agents")
+    elif mode == Mode.VOICE and current_mode == Mode.TEXT:
+        logger.info("Off-loading text agents, loading voice agents")
+        comm_agent = None
+        memory_agent = None
+        gc.collect()
+
+        voice_agent = VoiceCommunicationAgent()
+        voice_memory_agent = VoiceMemoryAgent()
+        logger.info("Successfully loaded voice agents")
+    else:
+        raise HTTPException(status_code=500, detail="Invalid state, restart server!")
+
+    current_mode = mode
+
+    return {"status": "ok"}
 
 
 @app.websocket("/voice-stream")


### PR DESCRIPTION
Closes #22 

## Implementation Details

- Added model/agent mode switching using a new endpoint `POST /switch` which can be used to switch to text or voice:

```
POST /switch?mode='text'

or 

POST /switch?mode='voice'
```

- If switching to current mode, it results in NO-OP, otherwise it unloads the current mode's agents out of memory and loads the new mode's agents.

- The default state of the server is always text mode. 
- Also added checks in the modality specific APIs (`/aprompt` and `/vprompt`) to first check if the mode is correct, because if not the agent objects would be in `None` state causing a 500 server error. 

## Testing

- Can see clearly memory usage increasing when switching to voice mode, and memory usage reducing when switched to text mode.