### PR TITLE
Add mode switching in frontend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -242,6 +242,11 @@ async def websocket_endpoint(websocket: WebSocket):
         filename.unlink(missing_ok=True)
 
 
+@app.get("/mode")
+def get_mode():
+    return {"mode": current_mode.value}
+
+
 if __name__ == "__main__":
     import uvicorn
 

--- a/frontend/src/components/KeyboardIcon.tsx
+++ b/frontend/src/components/KeyboardIcon.tsx
@@ -1,0 +1,27 @@
+// KeyboardIcon.tsx
+import React from 'react';
+
+const KeyboardIcon: React.FC = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="3" y="4" width="18" height="16" rx="2" ry="2"></rect>
+    <line x1="7" y1="8" x2="7" y2="8"></line>
+    <line x1="12" y1="8" x2="12" y2="8"></line>
+    <line x1="17" y1="8" x2="17" y2="8"></line>
+    <line x1="7" y1="12" x2="7" y2="12"></line>
+    <line x1="12" y1="12" x2="12" y2="12"></line>
+    <line x1="17" y1="12" x2="17" y2="12"></line>
+    <line x1="7" y1="16" x2="14" y2="16"></line>
+  </svg>
+);
+
+export default KeyboardIcon;

--- a/frontend/src/components/MicIcon.tsx
+++ b/frontend/src/components/MicIcon.tsx
@@ -1,0 +1,22 @@
+// MicIcon.tsx
+import React from 'react';
+
+const MicIcon: React.FC = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z"></path>
+    <path d="M19 10v2a7 7 0 0 1-14 0v-2"></path>
+    <line x1="12" y1="19" x2="12" y2="22"></line>
+  </svg>
+);
+
+export default MicIcon;

--- a/frontend/src/components/ModeToggle.css
+++ b/frontend/src/components/ModeToggle.css
@@ -1,0 +1,9 @@
+.mode-toggle {
+  cursor: pointer;
+  transition: transform 0.2s;
+  padding: 0px 20px;
+}
+
+.mode-toggle:hover {
+  transform: scale(1.1);
+}

--- a/frontend/src/components/ModeToggle.tsx
+++ b/frontend/src/components/ModeToggle.tsx
@@ -1,0 +1,18 @@
+// ModeToggle.tsx
+import React from "react";
+import MicIcon from "./MicIcon";
+import KeyboardIcon from "./KeyboardIcon";
+import "./ModeToggle.css";
+
+interface Props {
+  mode: string;
+  toggleMode: () => void;
+}
+
+const ModeToggle: React.FC<Props> = ({ mode, toggleMode }) => (
+  <div onClick={toggleMode} className="mode-toggle">
+    {mode === "text" ? <MicIcon /> : <KeyboardIcon />}
+  </div>
+);
+
+export default ModeToggle;


### PR DESCRIPTION
Closes #33 

## Implementation Details

- Add an endpoint `GET /mode` to return current state from backend, this is loaded on page loading as the current state. This is required because the backend maintains the mode state and frontend just caches it locally.
- Added a toggle button similar to theme toggle to toggle the mode.