### PR TITLE
Replace websocket with POST with multipart-form-data

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "ollama>=0.5.1",
     "pillow>=11.3.0",
     "pymongo>=4.13.2",
+    "python-multipart>=0.0.20",
     "timm>=1.0.17",
     "torch>=2.7.1",
     "torchaudio>=2.7.1",

--- a/backend/service/model/voice_memory_agent.py
+++ b/backend/service/model/voice_memory_agent.py
@@ -6,6 +6,7 @@ from langchain_core.runnables import RunnableConfig
 import json
 import uuid
 import logging
+from pathlib import Path
 
 from service.utils.environment import REDIS_HOST
 from service.utils.wav_utils import load_audio_from_file
@@ -146,3 +147,6 @@ Now extract information from this message. Return only valid JSON with no extra 
             graph.invoke(
                 {"messages": [{"role": "user", "content": user_message}]}, config
             )
+
+        file = Path(user_message)
+        file.unlink()

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -111,6 +111,7 @@ dependencies = [
     { name = "ollama" },
     { name = "pillow" },
     { name = "pymongo" },
+    { name = "python-multipart" },
     { name = "timm" },
     { name = "torch" },
     { name = "torchaudio" },
@@ -135,6 +136,7 @@ requires-dist = [
     { name = "ollama", specifier = ">=0.5.1" },
     { name = "pillow", specifier = ">=11.3.0" },
     { name = "pymongo", specifier = ">=4.13.2" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "timm", specifier = ">=1.0.17" },
     { name = "torch", specifier = ">=2.7.1" },
     { name = "torchaudio", specifier = ">=2.7.1" },
@@ -1212,6 +1214,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/69/d56f0897cc4932a336820c5d2470ffed50be04c624b07d1ad6ea75aaa975/pymongo-4.13.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:51040e1ba78d6671f8c65b29e2864483451e789ce93b1536de9cc4456ede87fa", size = 2219378, upload-time = "2025-06-16T18:16:04.108Z" },
     { url = "https://files.pythonhosted.org/packages/04/1e/427e7f99801ee318b6331062d682d3816d7e1d6b6013077636bd75d49c87/pymongo-4.13.2-cp313-cp313t-win32.whl", hash = "sha256:7ab86b98a18c8689514a9f8d0ec7d9ad23a949369b31c9a06ce4a45dcbffcc5e", size = 979460, upload-time = "2025-06-16T18:16:06.128Z" },
     { url = "https://files.pythonhosted.org/packages/b5/9c/00301a6df26f0f8d5c5955192892241e803742e7c3da8c2c222efabc0df6/pymongo-4.13.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c38168263ed94a250fc5cf9c6d33adea8ab11c9178994da1c3481c2a49d235f8", size = 1011057, upload-time = "2025-06-16T18:16:07.917Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/87/f44d7c9f274c7ee665a29b885ec97089ec5dc034c7f3fafa03da9e39a09e/python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13", size = 37158, upload-time = "2024-12-16T19:45:46.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/58/38b5afbc1a800eeea951b9285d3912613f2603bdf897a4ab0f4bd7f405fc/python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104", size = 24546, upload-time = "2024-12-16T19:45:44.423Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #43 

## Implementation Details

- Remove websocket `/voice-stream`, replaced with `POST /vprompt`.
- This now accepts the wav bytes as a multipart-form-data.
- Everything else remains the same, dumps the wav bytes into file and processes using both communication and memory agents.