### PR TITLE
Add god mode support with mock page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -10,6 +10,7 @@ import gc
 import uuid
 from pathlib import Path
 from dotenv import load_dotenv
+import os
 
 
 load_dotenv()
@@ -190,6 +191,11 @@ async def switch_mode(mode: Mode):
 @app.get("/mode")
 def get_mode():
     return {"mode": current_mode.value}
+
+
+@app.get("/privileges")
+def get_privileges():
+    return {"isGodMode": os.getenv("GOD_MODE") == "true"}
 
 
 if __name__ == "__main__":

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-markdown": "^10.1.0",
+        "react-router-dom": "^7.7.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -1997,6 +1998,14 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4247,6 +4256,42 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.7.0.tgz",
+      "integrity": "sha512-3FUYSwlvB/5wRJVTL/aavqHmfUKe0+Xm9MllkYgGo9eDwNdkvwlJGjpPxono1kCycLt6AnDTgjmXvK3/B4QGuw==",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.7.0.tgz",
+      "integrity": "sha512-wwGS19VkNBkneVh9/YD0pK3IsjWxQUVMDD6drlG7eJpo1rXBtctBqDyBm/k+oKHRAm1x9XWT3JFC82QI9YOXXA==",
+      "dependencies": {
+        "react-router": "7.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/recorder-audio-worklet": {
       "version": "6.0.49",
       "resolved": "https://registry.npmjs.org/recorder-audio-worklet/-/recorder-audio-worklet-6.0.49.tgz",
@@ -4435,6 +4480,11 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-markdown": "^10.1.0",
+    "react-router-dom": "^7.7.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,9 +1,11 @@
 import React from "react";
 import Chatbot from "./pages/Chatbot";
+import GodMode from "./pages/GodMode";
 import "./App.css";
 import { registerTool } from "./tools/tool-utils";
 import { playSound, stopSound } from "./tools/sound-tools";
 import { getLocation, LOCATION_RESULT } from "./tools/location-tools";
+import { Routes, Route } from "react-router-dom";
 
 registerTool(
   "playSound",
@@ -26,7 +28,10 @@ const App: React.FC = () => {
 
   return (
     <div className="App">
-      <Chatbot />
+      <Routes>
+        <Route path="/" element={<Chatbot />} />
+        <Route path="/god" element={<GodMode />} />
+      </Routes>
     </div>
   );
 };

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,5 +1,9 @@
 import { getPromptWithTools } from "../tools/tool-utils";
-import type { GetCurrentModeResponse, VoiceModeResponse } from "./model";
+import type {
+  GetCurrentModeResponse,
+  GetCurrentPrivilegesResponse,
+  VoiceModeResponse,
+} from "./model";
 import type { OptionalReadableBytesBuffer } from "./types";
 
 const API_HOST =
@@ -26,6 +30,22 @@ export const getCurrentMode = async (): Promise<GetCurrentModeResponse> => {
     }
   });
 };
+
+export const getCurrentPrivileges =
+  async (): Promise<GetCurrentPrivilegesResponse> => {
+    return fetch(`${API_HOST}/privileges`, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        ...getCfAuthHeaders(),
+      },
+    }).then((response) => {
+      if (response.ok) {
+        return response.json();
+      }
+    });
+  };
 
 export const getVoiceModeResponse = async (
   audioBlob: Blob

--- a/frontend/src/api/model.ts
+++ b/frontend/src/api/model.ts
@@ -2,6 +2,10 @@ export interface GetCurrentModeResponse {
   mode: string;
 }
 
+export interface GetCurrentPrivilegesResponse {
+  isGodMode: boolean;
+}
+
 export interface VoiceModeResponse {
   response: string;
 }

--- a/frontend/src/components/BackIcon.tsx
+++ b/frontend/src/components/BackIcon.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+const BackIcon: React.FC = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="feather feather-arrow-left"
+  >
+    <line x1="19" y1="12" x2="5" y2="12"></line>
+    <polyline points="12 19 5 12 12 5"></polyline>
+  </svg>
+);
+
+export default BackIcon;

--- a/frontend/src/components/RobotIcon.tsx
+++ b/frontend/src/components/RobotIcon.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+const RobotIcon: React.FC = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="6" y="4" width="12" height="16" rx="2" ry="2" />
+    <circle cx="12" cy="2" r="1" />
+    <line x1="12" y1="3" x2="12" y2="4" />
+    <circle cx="9" cy="9" r="1" />
+    <circle cx="15" cy="9" r="1" />
+    <rect x="9" y="12" width="6" height="2" rx="1" />
+    <line x1="6" y1="16" x2="4" y2="18" />
+    <line x1="18" y1="16" x2="20" y2="18" />
+  </svg>
+);
+
+export default RobotIcon;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,10 @@
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
+import { BrowserRouter } from "react-router-dom";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
-  <>
+  <BrowserRouter>
     <App />
-  </>
+  </BrowserRouter>
 );

--- a/frontend/src/pages/Chatbot.css
+++ b/frontend/src/pages/Chatbot.css
@@ -132,6 +132,10 @@
   transform: scale(1.05);
 }
 
+.chatbot.dark .chatbot-header button {
+  color: white;
+}
+
 .chatbot-header {
   padding: 20px;
   font-size: 1.5em;

--- a/frontend/src/pages/Chatbot.tsx
+++ b/frontend/src/pages/Chatbot.tsx
@@ -9,16 +9,22 @@ import { register } from "extendable-media-recorder";
 import { connect } from "extendable-media-recorder-wav-encoder";
 import {
   getCurrentMode,
+  getCurrentPrivileges,
   getTextModeResponse,
   getVoiceModeResponse,
   switchMode,
 } from "../api/api";
-import type { GetCurrentModeResponse } from "../api/model";
+import type {
+  GetCurrentModeResponse,
+  GetCurrentPrivilegesResponse,
+} from "../api/model";
 import {
   startRecordingAudio,
   stopRecordingAudio,
 } from "../utils/recording-utils";
 import { textResponseIteratorCleaner } from "../utils/stream-iterator";
+import RobotIcon from "../components/RobotIcon";
+import { useNavigate } from "react-router-dom";
 
 let encoderRegistered = false;
 
@@ -39,7 +45,9 @@ const Chatbot: React.FC = () => {
   const [theme, setTheme] = useState("dark");
   const [isRecording, setIsRecording] = useState(false);
   const [mode, setMode] = useState("text");
+  const [isGodMode, setIsGodMode] = useState(false);
   const messagesEndRef = useRef<null | HTMLDivElement>(null);
+  const navigate = useNavigate();
 
   /////////////////////////////////////////////////////////////////
   // STATE CHANGE PROCESSORS
@@ -51,6 +59,10 @@ const Chatbot: React.FC = () => {
 
     getCurrentMode().then((data: GetCurrentModeResponse) => {
       setMode(data.mode);
+    });
+
+    getCurrentPrivileges().then((data: GetCurrentPrivilegesResponse) => {
+      setIsGodMode(data.isGodMode);
     });
   }, []);
 
@@ -212,6 +224,11 @@ const Chatbot: React.FC = () => {
   return (
     <div className={`chatbot ${theme}`}>
       <div className="chatbot-header">
+        {isGodMode && (
+          <span onClick={() => navigate("/god")}>
+            <RobotIcon />
+          </span>
+        )}
         <div className="chatbot-header-title">ResQTalk</div>
         <ModeToggle mode={mode} toggleMode={toggleMode} />
         <ThemeToggle theme={theme} toggleTheme={toggleTheme} />

--- a/frontend/src/pages/GodMode.tsx
+++ b/frontend/src/pages/GodMode.tsx
@@ -1,0 +1,43 @@
+import React, { useState, useEffect } from 'react';
+import ThemeToggle from "../components/ThemeToggle";
+import BackIcon from "../components/BackIcon";
+import { useNavigate } from "react-router-dom";
+import { getCurrentPrivileges } from "../api/api";
+import type { GetCurrentPrivilegesResponse } from "../api/model";
+import "./Chatbot.css";
+
+const GodMode: React.FC = () => {
+  const [theme, setTheme] = useState("dark");
+  const [isGodMode, setIsGodMode] = useState(false);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    getCurrentPrivileges().then((data: GetCurrentPrivilegesResponse) => {
+      setIsGodMode(data.isGodMode);
+      if (!data.isGodMode) {
+        navigate("/");
+      }
+    });
+  }, [navigate]);
+
+  const toggleTheme = () => {
+    setTheme((prevTheme) => (prevTheme === "light" ? "dark" : "light"));
+  };
+
+  return (
+    isGodMode ? (
+      <div className={`chatbot ${theme}`}>
+        <div className="chatbot-header">
+          <span onClick={() => navigate("/")}>
+            <BackIcon />
+          </span>
+          <div className="chatbot-header-title">ResQTalk</div>
+          <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
+        </div>
+        <h1>Apun hi bhagwan</h1>
+      </div>
+    ) : null
+  );
+};
+
+export default GodMode;


### PR DESCRIPTION
## Implementation Details

- Add a env var `GOD_MODE` that when set to `true` will return true for `isGodMode` when `GET /privileges` is hit. 
- This allows the backend to control the god modeness.
- Add react router setup and a mock god mode page which can be navigated to only if `GET /privileges` returns `isGodMode: true`.