### PR TITLE
Add API to serve locally cached maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 dist/
 .env
 langfuse_*/
+offline_map.db

--- a/backend/service/utils/constants.py
+++ b/backend/service/utils/constants.py
@@ -2,3 +2,4 @@ COMM_AGENT_SYS_PROMPT_KEY = "communication-agent-sys-prompt"
 MEMORY_AGENT_SYS_PROMPT_KEY = "memory-agent-sys-prompt"
 
 MONGO_DB_NAME = "resqtalk"
+MAP_DB_NAME = "offline_map.db"

--- a/backend/service/utils/map_store.py
+++ b/backend/service/utils/map_store.py
@@ -1,0 +1,22 @@
+import sqlite3
+import os
+
+from service.utils.singleton import singleton
+from service.utils.constants import MAP_DB_NAME
+
+
+@singleton
+class MapStore:
+    def __init__(self):
+        if not os.path.exists(MAP_DB_NAME):
+            raise ValueError("No offline maps found")
+
+    def get_tile(self, x: int, y: int, z: int):
+        with sqlite3.connect(MAP_DB_NAME) as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT data from tiles WHERE z=? AND x=? AND y=?", (z, x, y)
+            )
+            result = cursor.fetchone()
+
+            return result[0] if result is not None and len(result) >= 1 else None

--- a/frontend/src/components/LocationMap.tsx
+++ b/frontend/src/components/LocationMap.tsx
@@ -7,6 +7,10 @@ interface LocationMapProps {
   longitude: string;
 }
 
+const OSM_TILE_SERVER =
+  import.meta.env.VITE_OSM_SERVER || "https://tile.openstreetmap.org";
+const TILE_SERVER_TEMPLATIZED_URL = `${OSM_TILE_SERVER}/{z}/{x}/{y}.png`;
+
 const LocationMap: React.FC<LocationMapProps> = ({ latitude, longitude }) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const mapInstance = useRef<L.Map | null>(null);
@@ -21,7 +25,7 @@ const LocationMap: React.FC<LocationMapProps> = ({ latitude, longitude }) => {
         13
       );
 
-      L.tileLayer("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png", {
+      L.tileLayer(TILE_SERVER_TEMPLATIZED_URL, {
         attribution:
           '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
       }).addTo(mapInstance.current);


### PR DESCRIPTION
## Implementation Details

- Added a interface to interact with SQLite DB containing locally cached maps. 
- Added a API `GET /map/{z}/{x}/{y}.png` in OpenStreetMap (OSM) tile request format. 
- Enabled loading local maps in frontend. 