### PR TITLE
Display map download status in maps page

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -385,6 +385,13 @@ def get_map_tiles(z: int, x: int, y: int):
     return Response(tile_data, media_type="image/png")
 
 
+@app.get("/map/download-status")
+def get_map_download_status():
+    map_store = MapStore()
+
+    return {"downloadStatus": map_store.get_download_status()}
+
+
 if __name__ == "__main__":
     import uvicorn
 

--- a/backend/service/utils/map_downloader.py
+++ b/backend/service/utils/map_downloader.py
@@ -136,6 +136,11 @@ class MapDownloader:
                             if len(tasks) >= 500:
                                 processed_tiles += await self.__gather_tasks(tasks)
 
+                                download_status = round(
+                                    processed_tiles / total_tiles * 100, 1
+                                )
+                                self.__map_store.update_download_status(download_status)
+
                                 tasks = []
 
                                 await asyncio.sleep(0.5)
@@ -149,11 +154,13 @@ class MapDownloader:
                                     )
 
                                 logger.info(
-                                    f"Progress: {processed_tiles}/{total_tiles} ({processed_tiles/total_tiles*100:.1f}%)"
+                                    f"Progress: {processed_tiles}/{total_tiles} ({download_status}%)"
                                 )
 
                     if tasks:
                         processed_tiles += await self.__gather_tasks(tasks)
+                        download_status = round(processed_tiles / total_tiles * 100, 1)
+                        self.__map_store.update_download_status(download_status)
 
                     logger.info(f"Completed zoom level {zoom}")
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -10,6 +10,7 @@ import type {
   OnboardingData,
   VoiceModeResponse,
   DisasterContext,
+  GetMapDownloadStatus,
 } from "./model";
 import type { OptionalReadableBytesBuffer } from "./types";
 
@@ -293,4 +294,19 @@ export const deleteDisasterContext = async () => {
   }
 
   return response.json();
+};
+
+export const getMapDownloadStatus = async (): Promise<GetMapDownloadStatus> => {
+  return await fetch(`${API_HOST}/map/download-status`, {
+    method: "GET",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...getCfAuthHeaders(),
+    },
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+  });
 };

--- a/frontend/src/api/model.ts
+++ b/frontend/src/api/model.ts
@@ -57,3 +57,7 @@ export interface DisasterContext {
   disaster: string;
   phase: string;
 }
+
+export interface GetMapDownloadStatus {
+  downloadStatus: number;
+}

--- a/frontend/src/pages/Maps.tsx
+++ b/frontend/src/pages/Maps.tsx
@@ -1,9 +1,12 @@
 import React, { useState, useEffect } from "react";
 import Navbar from "../components/Navbar";
 import { useTheme } from "../contexts/useTheme";
-import { getUserDetails } from "../api/api";
-import type { GetUserDetailsResponse } from "../api/model";
-import "./Chatbot.css"; 
+import { getUserDetails, getMapDownloadStatus } from "../api/api";
+import type {
+  GetUserDetailsResponse,
+  GetMapDownloadStatus as GetMapDownloadStatusResponse,
+} from "../api/model";
+import "./Chatbot.css";
 import LocationMap from "../components/LocationMap";
 import "./Maps.css";
 
@@ -12,6 +15,9 @@ const Maps: React.FC = () => {
   const [userDetails, setUserDetails] = useState<GetUserDetailsResponse | null>(
     null
   );
+  const [mapDownloadStatus, setMapDownloadStatus] =
+    useState<GetMapDownloadStatusResponse | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
     getUserDetails()
@@ -22,16 +28,34 @@ const Maps: React.FC = () => {
         console.error("Error fetching user details:", error);
         setUserDetails(null);
       });
+
+    getMapDownloadStatus()
+      .then((data: GetMapDownloadStatusResponse) => {
+        setMapDownloadStatus(data);
+        setLoading(false);
+      })
+      .catch((error) => {
+        console.error("Error fetching map download status:", error);
+        setMapDownloadStatus(null);
+        setLoading(false);
+      });
   }, []);
 
   return (
     <div className={`chatbot ${theme}`}>
       <Navbar pageTitle="Maps" />
       <div className="maps-container">
-        {userDetails && userDetails.location.latitude && userDetails.location.longitude ? (
+        {userDetails &&
+        userDetails.location.latitude &&
+        userDetails.location.longitude ? (
           <>
             <p>
-              Latitude: {userDetails.location.latitude}, Longitude: {userDetails.location.longitude}
+              Latitude: {userDetails.location.latitude}, Longitude:{" "}
+              {userDetails.location.longitude}
+            </p>
+            <p>
+              Map Cached Percent:{" "}
+              {loading ? "loading..." : `${mapDownloadStatus?.downloadStatus}%`}
             </p>
             <LocationMap
               latitude={userDetails.location.latitude.toString()}


### PR DESCRIPTION
## Implementation Details

- Add a new field in status table in map db to store the current status of map download.
- This is updated after every 500 tiles are processed (or the last x tiles are processed) by the map downloader.
- Exposed an API to get this information from map store.
- Added this information through API call in the maps page. 