### PR TITLE
Load checklist prompt from prompt store, allow editing from god mode

### DIFF
--- a/backend/service/data_models/checklist.py
+++ b/backend/service/data_models/checklist.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+from service.data_models.onboarding import Disaster
+
+
+class ChecklistAgentRequest(BaseModel):
+    disaster: Disaster
+    phase: str

--- a/backend/service/utils/constants.py
+++ b/backend/service/utils/constants.py
@@ -1,5 +1,6 @@
 COMM_AGENT_SYS_PROMPT_KEY = "communication-agent-sys-prompt"
 MEMORY_AGENT_SYS_PROMPT_KEY = "memory-agent-sys-prompt"
+CHECKLIST_AGENT_SYS_PROMPT_KEY = "checklist-agent-sys-prompt"
 
 MONGO_DB_NAME = "resqtalk"
 MAP_DB_NAME = "offline_map.db"

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -329,3 +329,22 @@ export const getMapDownloadStatus = async (): Promise<GetMapDownloadStatus> => {
     }
   });
 };
+
+export const runChecklistAgent = async (
+  disaster: string,
+  phase: string
+): Promise<GetChecklistResponse> => {
+  return fetch(`${API_HOST}/checklist-agent`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      ...getCfAuthHeaders(),
+    },
+    body: JSON.stringify({ disaster, phase }),
+  }).then((response) => {
+    if (response.ok) {
+      return response.json();
+    }
+  });
+};

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -52,6 +52,15 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+button:disabled {
+  background-color: #cccccc;
+  color: #666666;
+  cursor: not-allowed;
+  border-color: #cccccc;
+  animation: none;
+  background-image: none;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;

--- a/frontend/src/pages/GodMode.css
+++ b/frontend/src/pages/GodMode.css
@@ -51,6 +51,15 @@
   margin-top: 15px;
 }
 
+.prompt-box .chatbot-button:disabled {
+  background-color: #cccccc;
+  color: #666666;
+  cursor: not-allowed;
+  border-color: #cccccc;
+  animation: none;
+  background-image: none;
+}
+
 .memories-list {
   border: 1px solid #ddd;
   border-radius: 8px;
@@ -95,4 +104,52 @@
 
 .delete-user-button:hover {
   background-color: #c82333;
+}
+
+.checklist-controls {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+}
+
+.checklist-controls select {
+  width: 48%;
+  padding: 10px;
+  border-radius: 5px;
+  border: 1px solid #ddd;
+}
+
+.checklist-buttons {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+  margin-bottom: 15px;
+}
+
+.checklist-buttons .chatbot-button {
+  width: 48%;
+}
+
+.checklist-output-area {
+  margin-top: 15px;
+  padding: 15px;
+  border-radius: 8px;
+  border: 1px solid #ddd;
+  font-size: 1em;
+  resize: none;
+  min-height: 150px;
+  background-color: #f9f9f9;
+  color: #333;
+}
+
+.chatbot.dark .checklist-output-area {
+  background-color: #40444b;
+  border: 1px solid #555;
+  color: #ffffff;
+}
+
+.chatbot.dark .checklist-controls select {
+  background-color: #40444b;
+  border: 1px solid #555;
+  color: #ffffff;
 }


### PR DESCRIPTION
## Implementation Details

* New API Endpoint: Added a new /checklist-agent API endpoint (restricted to God Mode) to manually trigger
 checklist generation based on user info, disaster, and phase.
* God Mode UI Enhancements: Introduced a new section in the God Mode interface allowing users to:
   * View and edit the checklist agent's system prompt.
   * Select a disaster and phase.
   * Manually run the checklist agent and view its output.
* System Prompt Management: Integrated the checklist agent's system prompt into the existing prompt management
 system, allowing it to be loaded and saved via the backend.
