### PR TITLE
Make checklist forced generation prompt tunable

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -35,6 +35,8 @@ from service.utils.constants import (
     COMM_AGENT_SYS_PROMPT_KEY,
     MEMORY_AGENT_SYS_PROMPT_KEY,
     CHECKLIST_AGENT_SYS_PROMPT_KEY,
+    CHECKLIST_AGENT_FORCE_CHECKLIST_SYS_PROMPT_KEY,
+    VALID_PROMPT_KEYS,
     CACHED_MAP_RADIUS,
     CACHED_MAP_MIN_ZOOM_LEVEL,
     CACHED_MAP_MAX_ZOOM_LEVEL,
@@ -306,28 +308,15 @@ def _check_god_mode():
 @app.get("/prompt")
 def get_prompt(key: str):
     _check_god_mode()
-    if key == COMM_AGENT_SYS_PROMPT_KEY:
-        return {"prompt": SystemPromptStore().get_prompt(key=COMM_AGENT_SYS_PROMPT_KEY)}
-    elif key == MEMORY_AGENT_SYS_PROMPT_KEY:
-        return {
-            "prompt": SystemPromptStore().get_prompt(key=MEMORY_AGENT_SYS_PROMPT_KEY)
-        }
-    elif key == CHECKLIST_AGENT_SYS_PROMPT_KEY:
-        return {
-            "prompt": SystemPromptStore().get_prompt(key=CHECKLIST_AGENT_SYS_PROMPT_KEY)
-        }
-    else:
+    if key not in VALID_PROMPT_KEYS:
         raise HTTPException(status_code=400, detail=f"Invalid key: '{key}'")
+    return {"prompt": SystemPromptStore().get_prompt(key=key)}
 
 
 @app.put("/prompt")
 def set_prompt(request: SetPromptRequest):
     _check_god_mode()
-    if request.key not in [
-        COMM_AGENT_SYS_PROMPT_KEY,
-        MEMORY_AGENT_SYS_PROMPT_KEY,
-        CHECKLIST_AGENT_SYS_PROMPT_KEY,
-    ]:
+    if request.key not in VALID_PROMPT_KEYS:
         raise HTTPException(status_code=400, detail=f"Invalid key: '{request.key}'")
 
     SystemPromptStore().store_prompt(key=request.key, prompt=request.prompt)

--- a/backend/service/agents/checklist_agent.py
+++ b/backend/service/agents/checklist_agent.py
@@ -20,7 +20,10 @@ from service.data_models.onboarding import (
 from service.model.ollama_client import LangchainOllamaGemmaClient
 from service.utils.checklist_store import ChecklistStore
 from service.utils.prompt_store import SystemPromptStore
-from service.utils.constants import CHECKLIST_AGENT_SYS_PROMPT_KEY
+from service.utils.constants import (
+    CHECKLIST_AGENT_SYS_PROMPT_KEY,
+    CHECKLIST_AGENT_FORCE_CHECKLIST_SYS_PROMPT_KEY,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -206,19 +209,9 @@ class ChecklistBuilderAgent:
             logger.error(f"Failed to build checklist in {self.max_iterations} tries!")
             logger.info("Forcing model to generate checklist")
 
-            system_prompt = """
-            Given all the information, now YOU HAVE TO generate the checklist.
-
-            To generate checklist, all you have to do is create a list of items based on the information above that the person needs to have in the situation.
-
-            ALWAYS return the checklist in this format:
-            {{
-                "action": "final_answer",
-                "checklist": ["thing 1 that you think is useful to have based on all information", "other thing 2 based on all information"]
-            }}
-
-            Only return above JSON, and NOTHING else.
-            """
+            system_prompt = SystemPromptStore().get_prompt(
+                CHECKLIST_AGENT_FORCE_CHECKLIST_SYS_PROMPT_KEY
+            )
 
             messages = messages + [{"role": "system", "content": system_prompt}]
             response = await self.llm.ainvoke(messages)

--- a/backend/service/utils/constants.py
+++ b/backend/service/utils/constants.py
@@ -1,6 +1,16 @@
 COMM_AGENT_SYS_PROMPT_KEY = "communication-agent-sys-prompt"
 MEMORY_AGENT_SYS_PROMPT_KEY = "memory-agent-sys-prompt"
 CHECKLIST_AGENT_SYS_PROMPT_KEY = "checklist-agent-sys-prompt"
+CHECKLIST_AGENT_FORCE_CHECKLIST_SYS_PROMPT_KEY = (
+    "checklist-agent-force-checklist-sys-prompt"
+)
+
+VALID_PROMPT_KEYS = [
+    COMM_AGENT_SYS_PROMPT_KEY,
+    MEMORY_AGENT_SYS_PROMPT_KEY,
+    CHECKLIST_AGENT_SYS_PROMPT_KEY,
+    CHECKLIST_AGENT_FORCE_CHECKLIST_SYS_PROMPT_KEY,
+]
 
 MONGO_DB_NAME = "resqtalk"
 MAP_DB_NAME = "offline_map.db"

--- a/frontend/src/pages/GodMode.tsx
+++ b/frontend/src/pages/GodMode.tsx
@@ -28,6 +28,10 @@ const GodMode: React.FC = () => {
   const [communicationAgentPrompt, setCommunicationAgentPrompt] = useState("");
   const [memoryAgentPrompt, setMemoryAgentPrompt] = useState("");
   const [checklistAgentPrompt, setChecklistAgentPrompt] = useState("");
+  const [
+    checklistAgentForceChecklistPrompt,
+    setChecklistAgentForceChecklistPrompt,
+  ] = useState("");
   const [memories, setMemories] = useState<
     Array<Array<Record<string, unknown>>>
   >([]);
@@ -67,6 +71,12 @@ const GodMode: React.FC = () => {
     getSystemPrompt("checklist-agent-sys-prompt").then(
       (data: GetSystempPromptResponse) => {
         setChecklistAgentPrompt(data.prompt);
+      }
+    );
+
+    getSystemPrompt("checklist-agent-force-checklist-sys-prompt").then(
+      (data: GetSystempPromptResponse) => {
+        setChecklistAgentForceChecklistPrompt(data.prompt);
       }
     );
 
@@ -230,6 +240,30 @@ const GodMode: React.FC = () => {
               />
             </div>
           )}
+        </div>
+        <div className="prompt-box">
+          <label htmlFor="checklist-agent-force-checklist-prompt">
+            Checklist Agent Force Checklist System Prompt
+          </label>
+          <textarea
+            id="checklist-agent-force-checklist-prompt"
+            value={checklistAgentForceChecklistPrompt}
+            onChange={(e) =>
+              setChecklistAgentForceChecklistPrompt(e.target.value)
+            }
+            rows={10}
+          />
+          <button
+            className="chatbot-button"
+            onClick={() =>
+              handleSave(
+                "checklist-agent-force-checklist-sys-prompt",
+                checklistAgentForceChecklistPrompt
+              )
+            }
+          >
+            Save
+          </button>
         </div>
         <div className="prompt-box">
           <label htmlFor="memories">Memories</label>


### PR DESCRIPTION
## Implementation Details

- Made the system prompt for forceful checklist generation in final node of checklist agent tunable by exposing it to API and adding a new textarea in god mode. 