### PR TITLE
Add info display for current selected disaster and phase

### DIFF
--- a/frontend/src/components/InfoBubble.css
+++ b/frontend/src/components/InfoBubble.css
@@ -1,0 +1,19 @@
+.info-bubble {
+  position: absolute;
+  top: 100%; /* Position below the button */
+  right: 0; /* Align to the right of the parent */
+  background-color: #333; /* Dark gray for better contrast */
+  opacity: 1; /* Ensure full opacity */
+  border: 1px solid var(--border-color);
+  padding: 10px;
+  border-radius: 5px;
+  white-space: nowrap;
+  z-index: 100;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+}
+
+.info-bubble p {
+  margin: 0;
+  font-size: 0.9em;
+  color: #eee; /* Light gray for contrast with dark background */
+}

--- a/frontend/src/components/InfoButton.css
+++ b/frontend/src/components/InfoButton.css
@@ -1,0 +1,12 @@
+.info-button {
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: var(--primary-text-color);
+  margin-right: 20px;
+}
+
+.info-button:hover {
+  color: var(--accent-color);
+}

--- a/frontend/src/components/InfoIcon.tsx
+++ b/frontend/src/components/InfoIcon.tsx
@@ -1,0 +1,23 @@
+
+import React from 'react';
+
+const InfoIcon: React.FC = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className="feather feather-info"
+  >
+    <circle cx="12" cy="12" r="10"></circle>
+    <line x1="12" y1="16" x2="12" y2="12"></line>
+    <line x1="12" y1="8" x2="12" y2="8"></line>
+  </svg>
+);
+
+export default InfoIcon;

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,9 +1,12 @@
-import React from "react";
+import React, { useState } from "react";
 import GodModeNav from "./GodModeNav";
 import ThemeToggle from "./ThemeToggle";
 import { useTheme } from "../contexts/useTheme";
 import { useNavigate } from "react-router-dom";
+import InfoIcon from "./InfoIcon";
 import "./Navbar.css";
+import "./InfoButton.css";
+import "./InfoBubble.css";
 
 interface NavbarProps {
   pageTitle: string;
@@ -12,6 +15,14 @@ interface NavbarProps {
 const Navbar: React.FC<NavbarProps> = ({ pageTitle }) => {
   const { theme, toggleTheme } = useTheme();
   const navigate = useNavigate();
+  const [showInfoBubble, setShowInfoBubble] = useState(false);
+
+  const handleInfoClick = () => {
+    setShowInfoBubble(!showInfoBubble);
+  };
+
+  const selectedDisaster = localStorage.getItem("selectedDisaster") || "Not Set";
+  const disasterPhase = localStorage.getItem("disasterPhase") || "Not Set";
 
   return (
     <div className="chatbot-header">
@@ -20,6 +31,17 @@ const Navbar: React.FC<NavbarProps> = ({ pageTitle }) => {
       </div>
       <div className="chatbot-header-title" onClick={() => navigate('/')}>ResQTalk - {pageTitle}</div>
       <div className="navbar-right">
+        <div style={{ position: 'relative' }}>
+          <button className="info-button" onClick={handleInfoClick}>
+            <InfoIcon />
+          </button>
+          {showInfoBubble && (
+            <div className="info-bubble">
+              <p>Disaster: {selectedDisaster}</p>
+              <p>Phase: {disasterPhase}</p>
+            </div>
+          )}
+        </div>
         <ThemeToggle theme={theme} toggleTheme={toggleTheme} />
       </div>
     </div>

--- a/frontend/src/pages/Begin.tsx
+++ b/frontend/src/pages/Begin.tsx
@@ -57,6 +57,8 @@ const Begin: React.FC = () => {
           disaster: selectedDisaster,
           phase: disasterPhase,
         });
+        localStorage.setItem("selectedDisaster", selectedDisaster);
+        localStorage.setItem("disasterPhase", disasterPhase);
         navigate("/dashboard");
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
       } catch (_) {

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -14,6 +14,8 @@ const Dashboard: React.FC = () => {
       await deleteDisasterContext();
       localStorage.removeItem("checklist");
       localStorage.removeItem("checkedItems");
+      localStorage.removeItem("selectedDisaster");
+      localStorage.removeItem("disasterPhase");
       navigate("/begin");
     } catch (error) {
       console.error("Error deleting disaster context:", error);


### PR DESCRIPTION
## Implementation Details

- Cache the disaster context in local store.
- Add a info button and a info bubble, which can load the disaster context from local store and display in navbar in all pages. 
- Clear disaster context from local store when the disaster is to be changed. 